### PR TITLE
chore: add Claude Code config

### DIFF
--- a/.claude/hooks/protect-dotenv.sh
+++ b/.claude/hooks/protect-dotenv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+INPUT=$(cat)
+
+# Check file_path (Read, Edit) and path (Grep).
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+if [[ -n "$FILE_PATH" ]]; then
+  BASENAME=$(basename "$FILE_PATH")
+
+  # Allow '.env.example' through.
+  if [[ "$BASENAME" == ".env.example" ]]; then
+    exit 0
+  fi
+
+  # Unquoted RHS in [[ ]] is glob pattern matching, not regex.
+  if [[ "$BASENAME" == ".env" || "$BASENAME" == .env.* ]]; then
+    echo "Blocked: '$FILE_PATH' is a protected dotenv file" >&2
+    exit 2
+  fi
+fi
+
+# Check command (Bash) — match '.env' or '.env.*' anywhere in the command, excluding '.env.example'.
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+if [[ -n "$COMMAND" ]]; then
+  # Strip '.env.example' references so they don't trigger the block.
+  SANITIZED=$(echo "$COMMAND" | sed 's/\.env\.example//g')
+  
+  if [[ "$SANITIZED" =~ (^|[[:space:]/])\.env($|[[:space:]]) || "$SANITIZED" =~ (^|[[:space:]/])\.env\.[^[:space:]]+ ]]; then
+    echo "Blocked: command references a protected dotenv file" >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(.env)",
+      "Read(**/.env)",
+      "Edit(.env)",
+      "Edit(**/.env)",
+      "Bash(* .env)",
+      "Bash(* **/.env)",
+      "Grep(* .env)",
+      "Grep(* **/.env)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Bash|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/protect-dotenv.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,1 +1,3 @@
-.env
+# Ignore environment variables.
+*.env*
+!.env.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A unified platform that consolidates teacher-facing applications into day-to-day workflows.
+
+## Tech Stack
+
+- Go 1.26.1
+- PNPM 10
+- TypeScript 5.9
+- React 19
+- Vite 7
+- Tailwind CSS 4
+
+## Architecture
+
+- Monorepo: Go backend + React frontend
+- Config via environment variables with `TW_` prefix (see `.env.example`)
+- Go HTTP server uses standard library `net/http` — no framework
+
+## Build & Run Commands
+
+### Go
+
+```bash
+go build -o build/tw ./cmd/tw       # Build binary
+go run ./cmd/tw                     # Run directly
+go test ./...                       # Run all tests
+go test ./path/to/pkg               # Run single package tests
+go test -run TestName ./path/to/pkg # Run a specific test
+golangci-lint run                   # Static analysis
+```
+
+### Frontend
+
+```bash
+pnpm install                        # Install dependencies
+pnpm dev                            # Run Vite dev server
+pnpm build                          # Build production bundle
+pnpm lint                           # Run ESLint
+pnpm format                         # Run Prettier
+```
+
+## Formatting & Linting
+
+- Go: `golangci-lint run` (gofmt + goimports)
+- TS/JS: `pnpm lint` (ESLint), `pnpm format` (Prettier)
+- Pre-commit: Husky + lint-staged runs Prettier and ESLint on staged files
+
+## Test Conventions
+
+### Go
+
+#### Structure
+
+- Parent test + subtests. Small pure functions get standalone tests without subtests
+
+#### Naming
+
+- Outcome first, optionally followed by scenario: `"returns error on timeout"`, `"rejects invalid key"`
+- Table-driven subtests use just the distinguishing trait: `"missing XXX"`, `"wrong status code"`. The parent test name provides the verb context
+
+#### Assertions
+
+Use `want/got` style:
+
+- Error checks: `t.Fatalf("want nil, got: %v", err)` or `t.Fatal("want: err, got: nil)`
+- Field checks: `t.Errorf("want name: %q, got: %q", want, got)`
+- Containment: `t.Errorf("want err containing %q, got: %v", substr, err)`
+- When `got` isn't already captured, use an `if` initialiser: `if want, got := "XXX", resp.Header.Get("X-XXX"); want != got { ... }`
+
+### TypeScript
+
+- No frontend tests yet
+
+## Commit Conventions
+
+- Keep commit messages to a single summary line - no multi-line body/description. Details go in the PR description instead
+- Use conventional commit format (e.g. `feat:`, `fix:`, `test:`, `docs:`)
+- Use backticks around file names and variables names in commit message
+- Be specific - name the things being changed rather than using vague descriptions
+- Don't list implementation details (e.g. individual functions, internal mechanisms) - keep it high level
+- Make logical, incremental commits rather than one large commit
+- Always create a feature branch before starting work


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

Configure Claude Code for the repository by adding permission guards for sensitive dotenv files and project-level guidance via `CLAUDE.md`.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added `.claude/settings.json` with permission rules that deny Claude Code access to `.env` files
- Added `.claude/hooks/protect-dotenv.sh` as a pre-tool-use hook to block reads, edits, and greps on dotenv files (while allowing `.env.example`)
- Updated `.cursorignore` to broaden `.env` matching to `*.env*` and exclude `.env.example`
- Added `CLAUDE.md` with project overview, tech stack, architecture, build/run commands, formatting/linting, test
  conventions, and commit conventions